### PR TITLE
Fix comments, values, and tests

### DIFF
--- a/firmware/application/apps/ui_aprs_tx.hpp
+++ b/firmware/application/apps/ui_aprs_tx.hpp
@@ -100,7 +100,7 @@ class APRSTXView : public View {
     TransmitterView tx_view{
         16 * 16,
         5000,
-        0  // disable setting bandwith, since APRS used fixed 10k bandwidth
+        0  // disable setting bandwidth, since APRS used fixed 10k bandwidth
     };
 
     MessageHandlerRegistration message_handler_tx_progress{

--- a/firmware/application/freqman_db.cpp
+++ b/firmware/application/freqman_db.cpp
@@ -99,7 +99,7 @@ options_t freqman_bandwidths[6] = {
         {"3500k", 3500000},
         {"4000k", 4000000},
         {"4500k", 4500000},
-        {"5000k", 5500000},
+        {"5000k", 5000000},
         {"5500k", 5500000},  // Max capture, needs /4 decimation, (22Mhz sampling ADC).
     },
     {

--- a/firmware/application/ui/ui_spectrum.cpp
+++ b/firmware/application/ui/ui_spectrum.cpp
@@ -439,7 +439,7 @@ uint32_t filter_bandwidth_for_sampling_rate(int32_t sampling_rate) {
                           // Good BPF, good matching, we have some periodical M4 % samples drop.
             return 7'000'000;
 
-        default:  // BW capture 5,5Mhz, fs = 4 x 5,5Mhz = 22Mhz max ADC sampling and others.
+        default:  // BW capture 5.5 MHz, fs = 4 x 5.5 MHz = 22 MHz max ADC sampling and others.
                   // We tested also 9Mhz FPB slightly too much noise floor, better at 8Mhz.
             return 8'000'000;
     }

--- a/firmware/test/application/test_file_reader.cpp
+++ b/firmware/test/application/test_file_reader.cpp
@@ -154,9 +154,9 @@ TEST_CASE("count_lines returns 1 for single line") {
 }
 
 TEST_CASE("count_lines returns 2 for 2 lines") {
-    MockFile f{"abs"};
+    MockFile f{"a\nb"};
     BufferLineReader<MockFile> reader{f};
-    CHECK_EQ(count_lines(reader), 1);
+    CHECK_EQ(count_lines(reader), 2);
 }
 
 /* Simple example of how to use this to read settings by lines. */


### PR DESCRIPTION
## Summary
- fix APRS TX view comment typo
- correct 5 MHz value in frequency table
- clarify MHz notation in spectrum comment
- fix count_lines test

## Testing
- `./format-code.sh` *(fails: clang-format-13 not found)*
- `cmake -S firmware/test -B firmware/test/build` *(fails: missing CHIBIOS files)*

------
https://chatgpt.com/codex/tasks/task_e_6850d5f3ed088321af7b5acde926680f